### PR TITLE
Return mutable collection from sample()

### DIFF
--- a/src/main/java/gr/james/sampling/AbstractRandomSampling.java
+++ b/src/main/java/gr/james/sampling/AbstractRandomSampling.java
@@ -13,7 +13,6 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
     private final int sampleSize;
     private final Random random;
     private final List<T> sample;
-    private final Collection<T> unmodifiableSample;
     private long streamSize;
     private long skip;
 
@@ -40,7 +39,6 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
         this.streamSize = 0;
         this.sample = new ArrayList<>(sampleSize);
         this.skip = skipLength(sampleSize, sampleSize, random);
-        this.unmodifiableSample = Collections.unmodifiableList(sample);
     }
 
     /**
@@ -143,7 +141,7 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
      */
     @Override
     public final Collection<T> sample() {
-        return this.unmodifiableSample;
+        return this.sample;
     }
 
     /**


### PR DESCRIPTION
Hi!
I would like to use your library, but it has a very strong restriction that `sample` method returns an unmodifiable collection.

In my case, I want to sort `sample` results in order to build equi-depth histogram. But in order to do it, I should copy the unmodifiable collection and sort it. It requires extra space.

In this PR I removed `unmodifiableSample`. But maybe it would be better to allow a user to extend your library: remove `final`  and replace `private` with `protected` in AbstractRandomSampling class. What do you think?

