### PR TITLE
Rework stream overflow

### DIFF
--- a/src/main/java/gr/james/sampling/AbstractRandomSampling.java
+++ b/src/main/java/gr/james/sampling/AbstractRandomSampling.java
@@ -78,7 +78,7 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
      * @param item {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public boolean feed(T item) {
@@ -86,13 +86,9 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
         if (item == null) {
             throw new NullPointerException("Item was null");
         }
-        if (streamSize == Long.MAX_VALUE) {
-            throw new StreamOverflowException();
-        }
 
         // Increase stream size
         this.streamSize++;
-        assert this.streamSize > 0;
 
         // Fill the reservoir
         if (sample.size() < sampleSize) {
@@ -122,7 +118,7 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
      * @param items {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public boolean feed(Iterator<T> items) {
@@ -135,7 +131,7 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
      * @param items {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public boolean feed(Iterable<T> items) {
@@ -154,8 +150,10 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
     }
 
     /**
-     * Get the number of items that have been fed to the algorithm during the lifetime of this instance, which is a
-     * non-negative {@code long} value.
+     * Get the number of items that have been fed to the algorithm during the lifetime of this instance.
+     * <p>
+     * If more than {@link Long#MAX_VALUE} items has been fed to the instance, {@code streamSize()} will cycle the long
+     * values, continuing from {@link Long#MIN_VALUE}.
      * <p>
      * This method runs in constant time.
      *
@@ -163,7 +161,6 @@ public abstract class AbstractRandomSampling<T> implements RandomSampling<T> {
      */
     @Override
     public long streamSize() {
-        assert this.streamSize >= 0;
         return this.streamSize;
     }
 

--- a/src/main/java/gr/james/sampling/AbstractThreadSafeRandomSampling.java
+++ b/src/main/java/gr/james/sampling/AbstractThreadSafeRandomSampling.java
@@ -88,7 +88,7 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
      * @param item {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public final boolean feed(T item) {
@@ -96,14 +96,9 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
         if (item == null) {
             throw new NullPointerException("Item was null");
         }
-        if (streamSize.get() == Long.MAX_VALUE) {
-            throw new StreamOverflowException();
-        }
 
         // Increase stream size
         long streamSize = this.streamSize.incrementAndGet();
-        assert streamSize > 0;
-
 
         // attempt to add to samples while we don't have a full count yet, until successful or array is full
         for (int samplesInArray = samplesCount.get(); samplesInArray < sampleSize; ) {
@@ -142,7 +137,7 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
      * @param items {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public final boolean feed(Iterator<T> items) {
@@ -155,7 +150,7 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
      * @param items {@inheritDoc}
      * @return {@inheritDoc}
      * @throws NullPointerException    {@inheritDoc}
-     * @throws StreamOverflowException if the number of items fed exceeds {@link Long#MAX_VALUE}
+     * @throws StreamOverflowException {@inheritDoc}
      */
     @Override
     public final boolean feed(Iterable<T> items) {
@@ -174,8 +169,10 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
     }
 
     /**
-     * Get the number of items that have been fed to the algorithm during the lifetime of this instance, which is a
-     * non-negative {@code long} value.
+     * Get the number of items that have been fed to the algorithm during the lifetime of this instance.
+     * <p>
+     * If more than {@link Long#MAX_VALUE} items has been fed to the instance, {@code streamSize()} will cycle the long
+     * values, continuing from {@link Long#MIN_VALUE}.
      * <p>
      * This method runs in constant time.
      *
@@ -183,7 +180,6 @@ public abstract class AbstractThreadSafeRandomSampling<T> implements RandomSampl
      */
     @Override
     public final long streamSize() {
-        assert this.streamSize.get() >= 0;
         return this.streamSize.get();
     }
 

--- a/src/main/java/gr/james/sampling/LiLSampling.java
+++ b/src/main/java/gr/james/sampling/LiLSampling.java
@@ -66,7 +66,7 @@ public class LiLSampling<T> extends AbstractRandomSampling<T> {
         public LiLSkipFunction(int sampleSize, Random random) {
             this.sampleSizeReverse = 1.0 / sampleSize;
             this.random = random;
-            this.W = Math.pow(RandomSamplingUtils.randomExclusive(random), 1.0 / sampleSize);
+            this.W = Math.pow(RandomSamplingUtils.randomExclusive(random), sampleSizeReverse);
         }
 
         @Override

--- a/src/main/java/gr/james/sampling/LiLSampling.java
+++ b/src/main/java/gr/james/sampling/LiLSampling.java
@@ -59,12 +59,12 @@ public class LiLSampling<T> extends AbstractRandomSampling<T> {
     }
 
     private static class LiLSkipFunction implements SkipFunction {
-        private final int sampleSize;
+        private final double sampleSizeReverse;
         private final Random random;
-        private double W;
+        public double W;
 
         public LiLSkipFunction(int sampleSize, Random random) {
-            this.sampleSize = sampleSize;
+            this.sampleSizeReverse = 1.0 / sampleSize;
             this.random = random;
             this.W = Math.pow(RandomSamplingUtils.randomExclusive(random), 1.0 / sampleSize);
         }
@@ -73,13 +73,13 @@ public class LiLSampling<T> extends AbstractRandomSampling<T> {
         public long skip() throws StreamOverflowException {
             final double random1 = RandomSamplingUtils.randomExclusive(random);
             final double random2 = RandomSamplingUtils.randomExclusive(random);
-            long skip = (long) (Math.log(random1) / Math.log(1 - W));
-            assert skip >= 0 || skip == Long.MIN_VALUE;
-            if (skip == Long.MIN_VALUE) {  // Sometimes when W is very small, 1 - W = 1 and Math.log(1) = +0 instead of -0
-                skip = Long.MAX_VALUE;     // This results in negative infinity skip
+            final double skipDouble = Math.log(random1) / Math.log(1 - W);
+            assert skipDouble > 0 ^ skipDouble == Double.NEGATIVE_INFINITY; // Can be -Inf if W is tiny
+            if (skipDouble > Long.MAX_VALUE || skipDouble < 0) {
+                throw new StreamOverflowException();
             }
-            // W = W * Math.exp(Math.log(random2) / sampleSize);
-            W = W * Math.pow(random2, 1.0 / sampleSize);
+            final long skip = (long) skipDouble;
+            W = W * Math.pow(random2, sampleSizeReverse);
             return skip;
         }
     }

--- a/src/main/java/gr/james/sampling/LiLSamplingThreadSafe.java
+++ b/src/main/java/gr/james/sampling/LiLSamplingThreadSafe.java
@@ -65,15 +65,15 @@ public class LiLSamplingThreadSafe<T> extends AbstractThreadSafeRandomSampling<T
     }
 
     private static class LiLThreadSafeSkipFunction implements SkipFunction {
-        private final int sampleSize;
+        private final double sampleSizeReverse;
         private final Random random;
         private final AtomicLong W;
 
         public LiLThreadSafeSkipFunction(int sampleSize, Random random) {
-            this.sampleSize = sampleSize;
+            this.sampleSizeReverse = 1.0 / sampleSize;
             this.random = random;
             W = new AtomicLong();
-            W.set(Double.doubleToLongBits(Math.pow(RandomSamplingUtils.randomExclusive(random), 1.0 / sampleSize)));
+            W.set(Double.doubleToLongBits(Math.pow(RandomSamplingUtils.randomExclusive(random), sampleSizeReverse)));
         }
 
         @Override
@@ -81,13 +81,13 @@ public class LiLSamplingThreadSafe<T> extends AbstractThreadSafeRandomSampling<T
             final double random1 = RandomSamplingUtils.randomExclusive(random);
             final double random2 = RandomSamplingUtils.randomExclusive(random);
             double w = Double.longBitsToDouble(W.get());
-            long skip = (long) (Math.log(random1) / Math.log(1 - w));
-            assert skip >= 0 || skip == Long.MIN_VALUE;
-            if (skip == Long.MIN_VALUE) {  // Sometimes when W is very small, 1 - W = 1 and Math.log(1) = +0 instead of -0
-                skip = Long.MAX_VALUE;     // This results in negative infinity skip
+            final double skipDouble = Math.log(random1) / Math.log(1 - w);
+            assert skipDouble > 0 ^ skipDouble == Double.NEGATIVE_INFINITY; // Can be -Inf if W is tiny
+            if (skipDouble > Long.MAX_VALUE || skipDouble < 0) {
+                throw new StreamOverflowException();
             }
-            // W = W * Math.pow(random2, 1.0 / sampleSize);
-            W.set(Double.doubleToLongBits(w * Math.pow(random2, 1.0 / sampleSize)));
+            final long skip = (long) skipDouble;
+            W.set(Double.doubleToLongBits(w * Math.pow(random2, sampleSizeReverse)));
             return skip;
         }
     }

--- a/src/main/java/gr/james/sampling/VitterXSampling.java
+++ b/src/main/java/gr/james/sampling/VitterXSampling.java
@@ -69,23 +69,19 @@ public class VitterXSampling<T> extends AbstractRandomSampling<T> {
 
         @Override
         public long skip() throws StreamOverflowException {
-            if (streamSize == Long.MAX_VALUE) {
-                throw new StreamOverflowException();
-            }
-
-            streamSize++;
-
             final double r = random.nextDouble();
-            long skipCount = 0;
-
-            double quot = (streamSize - sampleSize) / (double) streamSize;
-            while (quot > r && streamSize > 0) {
-                skipCount++;
-                streamSize++;
-                quot = (quot * (streamSize - sampleSize)) / (double) streamSize;
+            long skip = 0;
+            double quot = 1;
+            while (true) {
+                if (++streamSize < 0) {
+                    throw new StreamOverflowException();
+                }
+                quot *= (streamSize - sampleSize) / (double) streamSize;
+                if (quot <= r) {
+                    return skip;
+                }
+                skip++;
             }
-
-            return skipCount;
         }
     }
 }

--- a/src/main/java/gr/james/sampling/WatermanSampling.java
+++ b/src/main/java/gr/james/sampling/WatermanSampling.java
@@ -69,16 +69,16 @@ public class WatermanSampling<T> extends AbstractRandomSampling<T> {
 
         @Override
         public long skip() throws StreamOverflowException {
-            if (streamSize == Long.MAX_VALUE) {
-                throw new StreamOverflowException();
+            long skip = 0;
+            while (true) {
+                if (++streamSize < 0) {
+                    throw new StreamOverflowException();
+                }
+                if (random.nextDouble() * streamSize < sampleSize) {
+                    return skip;
+                }
+                skip++;
             }
-            streamSize++;
-            long skipCount = 0;
-            while (random.nextDouble() * streamSize >= sampleSize && streamSize > 0) {
-                streamSize++;
-                skipCount++;
-            }
-            return skipCount;
         }
     }
 }


### PR DESCRIPTION
Abstract unweighted classes no longer throw `StreamOverflowException`. Instead individual implementations have their own logic of throwing this exception.