### PR TITLE
Add test for large stream sizes

### DIFF
--- a/src/test/java/gr/james/sampling/RandomSamplingTest.java
+++ b/src/test/java/gr/james/sampling/RandomSamplingTest.java
@@ -107,6 +107,17 @@ public class RandomSamplingTest {
     }
 
     /**
+     * All implementations should handle 2^28 stream size without problems.
+     */
+    @Test
+    public void largeStream() {
+        final RandomSampling<Integer> rs = impl.get();
+        for (long i = 0; i < 0x10000000L; i++) {
+            rs.feed(0);
+        }
+    }
+
+    /**
      * Equivalence between {@link RandomSampling#feed(Object)}, {@link RandomSampling#feed(Iterator)} and
      * {@link RandomSampling#feed(Iterable)}.
      */


### PR DESCRIPTION
Add a test for a stream of $2^{28}$ elements. The test shouldn't fail and should be fast too.